### PR TITLE
Migrate from kotlinx-io to ktor-io.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ jsBrowserTest.doFirst {
 }
 
 dependencies {
-    commonMainImplementation "org.jetbrains.kotlinx:kotlinx-io:0.1.16"
+    commonMainImplementation "io.ktor:ktor-io:1.5.4"
     commonMainImplementation "org.jetbrains.kotlinx:kotlinx-serialization-core:1.1.0"
     commonMainImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
     commonMainImplementation "net.mamoe.yamlkt:yamlkt:0.9.0"
@@ -68,7 +68,6 @@ dependencies {
     commonTestImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common"
     commonTestImplementation "org.jetbrains.kotlin:kotlin-test-common"
 
-    jvmMainImplementation "org.jetbrains.kotlinx:kotlinx-io-jvm:0.1.16"
     jvmMainImplementation "org.apache.pdfbox:pdfbox:2.0.9"
     jvmMainImplementation "org.glassfish:javax.json:1.1.2"
     jvmMainImplementation "org.jsoup:jsoup:1.11.2"
@@ -76,7 +75,6 @@ dependencies {
     jvmTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
     jvmTestImplementation "org.jetbrains.kotlin:kotlin-test-junit"
 
-    jsMainImplementation "org.jetbrains.kotlinx:kotlinx-io-js:0.1.16"
     jsMainImplementation(npm("jszip", "3.4.0"))
     jsMainImplementation(npm("text-encoding", "0.7.0"))
     jsMainImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.4.2"

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/AcrossLite.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/AcrossLite.kt
@@ -3,18 +3,19 @@ package com.jeffpdavidson.kotwords.formats
 import com.jeffpdavidson.kotwords.model.BLACK_SQUARE
 import com.jeffpdavidson.kotwords.model.Crossword
 import com.jeffpdavidson.kotwords.model.Square
-import kotlinx.io.charsets.Charsets
-import kotlinx.io.core.BytePacketBuilder
-import kotlinx.io.core.ByteReadPacket
-import kotlinx.io.core.String
-import kotlinx.io.core.buildPacket
-import kotlinx.io.core.discardExact
-import kotlinx.io.core.readBytes
-import kotlinx.io.core.readShortLittleEndian
-import kotlinx.io.core.toByteArray
-import kotlinx.io.core.writeFully
-import kotlinx.io.core.writeLongLittleEndian
-import kotlinx.io.core.writeShortLittleEndian
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.BytePacketBuilder
+import io.ktor.utils.io.core.ByteReadPacket
+import io.ktor.utils.io.core.String
+import io.ktor.utils.io.core.buildPacket
+import io.ktor.utils.io.core.fill
+import io.ktor.utils.io.core.readBytes
+import io.ktor.utils.io.core.readShortLittleEndian
+import io.ktor.utils.io.core.toByteArray
+import io.ktor.utils.io.core.writeFully
+import io.ktor.utils.io.core.writeLongLittleEndian
+import io.ktor.utils.io.core.writeShortLittleEndian
+import io.ktor.utils.io.core.writeText
 
 private const val FILE_MAGIC = "ACROSS&DOWN"
 private const val FORMAT_VERSION = "1.4"
@@ -192,7 +193,7 @@ class AcrossLite(val binaryData: ByteArray) : Crosswordable {
                 name: String, length: Int,
                 writeDataFn: (BytePacketBuilder) -> Unit
             ) {
-                writeStringUtf8(name)
+                writeText(name, charset = Charsets.ISO_8859_1)
                 writeShortLittleEndian(length.toShort())
 
                 // Write the data to a separate packet so we can calculate the checksum.
@@ -305,7 +306,7 @@ class AcrossLite(val binaryData: ByteArray) : Crosswordable {
                         "${if (it.value < 10) " " else ""}${it.value}:${it.key}"
                     }
                     writeExtraSection("RTBL", rtblData.length) { packetBuilder ->
-                        packetBuilder.writeStringUtf8(rtblData)
+                        packetBuilder.writeText(rtblData, charset = Charsets.UTF_8)
                     }
 
                     if (solved) {
@@ -336,7 +337,7 @@ class AcrossLite(val binaryData: ByteArray) : Crosswordable {
                 if (solved) {
                     // LTIM section: timer (stopped at 0).
                     writeExtraSection("LTIM", 3) { packetBuilder ->
-                        packetBuilder.writeStringUtf8("0,1")
+                        packetBuilder.writeText("0,1", charset = Charsets.ISO_8859_1)
                     }
                 }
 

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/Jpz.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/Jpz.kt
@@ -3,8 +3,8 @@ package com.jeffpdavidson.kotwords.formats
 import com.jeffpdavidson.kotwords.model.BLACK_SQUARE
 import com.jeffpdavidson.kotwords.model.Crossword
 import com.jeffpdavidson.kotwords.model.Square
-import kotlinx.io.charsets.Charsets
-import kotlinx.io.core.toByteArray
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/PuzzleMe.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/PuzzleMe.kt
@@ -5,7 +5,7 @@ import com.jeffpdavidson.kotwords.formats.json.PuzzleMeJson
 import com.jeffpdavidson.kotwords.model.BLACK_SQUARE
 import com.jeffpdavidson.kotwords.model.Crossword
 import com.jeffpdavidson.kotwords.model.Square
-import kotlinx.io.core.String
+import io.ktor.utils.io.core.String
 
 private val PUZZLE_DATA_REGEX = """\bwindow\.rawc\s*=\s*'([^']+)'""".toRegex()
 

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/RowsGarden.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/RowsGarden.kt
@@ -1,8 +1,8 @@
 package com.jeffpdavidson.kotwords.formats
 
 import com.jeffpdavidson.kotwords.model.Puzzle
-import kotlinx.io.charsets.Charsets
-import kotlinx.io.core.String
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.String
 import kotlinx.serialization.Serializable
 import net.mamoe.yamlkt.Yaml
 import kotlin.math.floor

--- a/src/jsMain/kotlin/com/jeffpdavidson/kotwords/web/AcrosticForm.kt
+++ b/src/jsMain/kotlin/com/jeffpdavidson/kotwords/web/AcrosticForm.kt
@@ -8,10 +8,10 @@ import com.jeffpdavidson.kotwords.web.html.FormFields
 import com.jeffpdavidson.kotwords.web.html.Html.renderPage
 import com.jeffpdavidson.kotwords.web.html.Tabs
 import com.jeffpdavidson.kotwords.web.html.Tabs.tabs
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.String
 import kotlinx.html.InputType
 import kotlinx.html.dom.append
-import kotlinx.io.charsets.Charsets
-import kotlinx.io.core.String
 import kotlin.js.Promise
 
 /** Form to convert Acrostic puzzles into JPZ files. */


### PR DESCRIPTION
kotlinx-io development seems to have been frozen for a while, though it
might resume in the future; ktor-io is the current active development
target. The main alternative, okio, doesn't support non-UTF-8 charsets
in Javascript, as are needed for Across Lite encoding/decoding.