### PR TITLE
Support missing bylines for WSJ

### DIFF
--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournal.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournal.kt
@@ -50,7 +50,7 @@ class WallStreetJournal(
         }.unescapeEntities()
         return Crossword(
             title = title,
-            creator = response.data.copy.byline.unescapeEntities(),
+            creator = response.data.copy.byline?.unescapeEntities() ?: "",
             copyright = "\u00a9 ${date.yearInt} ${response.data.copy.publisher.unescapeEntities()}",
             description = description,
             grid = grid,

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalAcrostic.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalAcrostic.kt
@@ -27,7 +27,7 @@ class WallStreetJournalAcrostic(private val json: String) : DelegatingPuzzleable
         val date = PUBLISH_DATE_FORMAT.parse(publishDate)
         return Acrostic(
             title = title,
-            creator = decodeHtmlEntities(response.copy.byline),
+            creator = decodeHtmlEntities(response.copy.byline ?: ""),
             copyright = "\u00a9 ${date.yearInt} ${decodeHtmlEntities(response.copy.publisher)}",
             description = "",
             suggestedWidth = response.copy.gridsize.cols,

--- a/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/json/WallStreetJournalJson.kt
+++ b/src/commonMain/kotlin/com/jeffpdavidson/kotwords/formats/json/WallStreetJournalJson.kt
@@ -19,7 +19,7 @@ internal object WallStreetJournalJson {
     @Serializable
     internal data class Copy(
         val title: String,
-        val byline: String,
+        val byline: String? = null,
         val description: String?,
         @SerialName("crosswordadditionalcopy") val crosswordAdditionalCopy: String? = null,
         @SerialName("date-publish") val datePublish: String,

--- a/src/commonTest/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalAcrosticTest.kt
+++ b/src/commonTest/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalAcrosticTest.kt
@@ -27,4 +27,25 @@ class WallStreetJournalAcrosticTest {
             ), acrostic.getPuzzleable()
         )
     }
+
+    @Test
+    fun acrosticPuzzleNoByline() = runTest {
+        val acrostic = WallStreetJournalAcrostic(
+            readStringResource(WallStreetJournalAcrosticTest::class, "wsj/test-acrostic-no-byline.json"),
+        )
+        assertEquals(
+            Acrostic(
+                title = "Test title",
+                creator = "",
+                copyright = "© 2021 Test publisher",
+                description = "",
+                suggestedWidth = 20,
+                solution = "ACRO-ST IC",
+                gridKey = listOf(listOf(2, 1, 3), listOf(5, 6, 4, 7, 8)),
+                clues = listOf("Clue 1", "Clue 2"),
+                completionMessage = "Quote author, “Quote”",
+                includeAttribution = true,
+            ), acrostic.getPuzzleable()
+        )
+    }
 }

--- a/src/commonTest/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalTest.kt
+++ b/src/commonTest/kotlin/com/jeffpdavidson/kotwords/formats/WallStreetJournalTest.kt
@@ -30,4 +30,16 @@ class WallStreetJournalTest {
             )
         )
     }
+
+    @Test
+    fun noByline() = runTest {
+        assertTrue(
+            readBinaryResource(WallStreetJournalTest::class, "puz/test-no-byline.puz").contentEquals(
+                WallStreetJournal(
+                    readStringResource(WallStreetJournalTest::class, "wsj/test-no-byline.json"),
+                    includeDateInTitle = false
+                ).asPuzzle().asAcrossLiteBinary()
+            )
+        )
+    }
 }

--- a/src/commonTest/resources/wsj/test-acrostic-no-byline.json
+++ b/src/commonTest/resources/wsj/test-acrostic-no-byline.json
@@ -1,0 +1,27 @@
+{
+  "copy": {
+    "title": "Test title",
+    "description": "Quote author, &ldquo;Quote&rdquo;",
+    "publisher": "Test publisher",
+    "date-publish": "Saturday, 31 July 2021",
+    "gridsize": {
+      "cols": "20",
+      "rows": "0"
+    }
+  },
+  "settings": {
+    "solution": "ACRO-ST IC",
+    "clues": [
+      {
+        "id": "A",
+        "clue": "Clue 1"
+      },
+      {
+        "id": "B",
+        "clue": "Clue 2"
+      }
+    ]
+  },
+  "celldata": "AAAB-BB BB",
+  "cluedata": "BACC-AB DE"
+}

--- a/src/commonTest/resources/wsj/test-no-byline.json
+++ b/src/commonTest/resources/wsj/test-no-byline.json
@@ -1,0 +1,186 @@
+{
+  "data": {
+    "copy": {
+      "title": "Example Puzzle for Kotwords",
+      "description": "Notepad&#32;text goes here.",
+      "publisher": "Jeff Davidson",
+      "date-publish": "Tuesday, 10 April 2018",
+      "gridsize": {
+        "cols": "5",
+        "rows": "5"
+      },
+      "clues": [
+        {
+          "title": "Across",
+          "clues": [
+            {
+              "number": "1",
+              "clue": "First across clue with special characters αβγδε"
+            },
+            {
+              "number": "5",
+              "clue": "Second across clue"
+            },
+            {
+              "number": "6",
+              "clue": "Third across clue"
+            },
+            {
+              "number": "8",
+              "clue": "Fourth across clue"
+            },
+            {
+              "number": "9",
+              "clue": "Fifth across clue"
+            }
+          ]
+        },
+        {
+          "title": "Down",
+          "clues": [
+            {
+              "number": "1",
+              "clue": "First down clue"
+            },
+            {
+              "number": "2",
+              "clue": "Second down clue"
+            },
+            {
+              "number": "3",
+              "clue": "Third down clue"
+            },
+            {
+              "number": "4",
+              "clue": "Fourth down clue"
+            },
+            {
+              "number": "7",
+              "clue": "Fifth&#32;down clue"
+            }
+          ]
+        }
+      ]
+    },
+    "grid": [
+      [
+        {
+          "Letter": "A",
+          "Blank": ""
+        },
+        {
+          "Letter": "B",
+          "Blank": ""
+        },
+        {
+          "Letter": "C",
+          "Blank": ""
+        },
+        {
+          "Letter": "D",
+          "Blank": ""
+        },
+        {
+          "Letter": "",
+          "Blank": "blank"
+        }
+      ],
+      [
+        {
+          "Letter": "E",
+          "Blank": ""
+        },
+        {
+          "Letter": "F",
+          "Blank": ""
+        },
+        {
+          "Letter": "G",
+          "Blank": ""
+        },
+        {
+          "Letter": "H",
+          "Blank": ""
+        },
+        {
+          "Letter": "",
+          "Blank": "blank"
+        }
+      ],
+      [
+        {
+          "Letter": "I",
+          "style": {
+            "shapebg": "circle",
+            "highlight": false
+          },
+          "Blank": ""
+        },
+        {
+          "Letter": "J",
+          "Blank": ""
+        },
+        {
+          "Letter": "XYZ",
+          "Blank": ""
+        },
+        {
+          "Letter": "L",
+          "Blank": ""
+        },
+        {
+          "Letter": "M",
+          "style": {
+            "shapebg": "circle",
+            "highlight": false
+          },
+          "Blank": ""
+        }
+      ],
+      [
+        {
+          "Letter": "",
+          "Blank": "blank"
+        },
+        {
+          "Letter": "N",
+          "Blank": ""
+        },
+        {
+          "Letter": "O",
+          "Blank": ""
+        },
+        {
+          "Letter": "P",
+          "Blank": ""
+        },
+        {
+          "Letter": "Q",
+          "Blank": ""
+        }
+      ],
+      [
+        {
+          "Letter": "",
+          "Blank": "blank"
+        },
+        {
+          "Letter": "1",
+          "Blank": ""
+        },
+        {
+          "Letter": "2",
+          "Blank": ""
+        },
+        {
+          "Letter": "$",
+          "Blank": ""
+        },
+        {
+          "Letter": "@",
+          "Blank": ""
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
For the moment, this isn't generating the .puz for the crossword test.

Fixes: https://github.com/jpd236/CrosswordScraper/issues/38

I thought I'd give this a shot, but I'm missing some subtleties here about nullability, I think.